### PR TITLE
templates: fix table overflow on small screen

### DIFF
--- a/templates/docs/page.html
+++ b/templates/docs/page.html
@@ -227,5 +227,17 @@
         {{template "docs/navbar" .}}
       </div>
     </div>
+
+    <script>
+      // Wrap all <table> with a <div> to be able to have "overflow-y: auto"
+      document.querySelectorAll('table').forEach(
+        function(table) {
+          var div = document.createElement('div');
+          div.style.overflowY = 'auto';
+          table.parentNode.insertBefore(div, table);
+          div.appendChild(table);
+        }
+      );
+    </script>
   </body>
 </html>

--- a/templates/docs/page.html
+++ b/templates/docs/page.html
@@ -216,8 +216,8 @@
     </div>
 
     <div class="fixed z-50 inset-0 overflow-y-auto" style="display: none" x-show="showNavbar">
-      <div class="fixed inset-0 bg-black/20 backdrop-blur-sm dark:bg-slate-900/80" id="headlessui-dialog-overlay-15" aria-hidden="true"></div>
-      <div class="relative bg-white w-80 max-w-[calc(100%-3rem)] p-6 dark:bg-slate-800">
+      <div class="fixed inset-0 bg-black/20 backdrop-blur-sm dark:bg-slate-900/80" aria-hidden="true"></div>
+      <div class="relative bg-white w-80 max-w-[calc(100%-3rem)] p-6 dark:bg-slate-800 h-screen">
         <button type="button" class="absolute z-10 top-5 right-5 w-8 h-8 flex items-center justify-center text-slate-500 hover:text-slate-600 dark:text-slate-400 dark:hover:text-slate-300" tabindex="0" @click="showNavbar = false">
           <span class="sr-only">Close navigation</span>
           <svg viewBox="0 0 10 10" class="w-2.5 h-2.5 overflow-visible">


### PR DESCRIPTION
### Describe the pull request

Table content was truncated on small-enough screens, this PR adds JavaScript code to wrap all `<table>` elements with a parent `<div>` to be able to correctly set the `overflow-y: auto` style.

<img src="https://user-images.githubusercontent.com/2946214/165305154-e352656d-e5cb-4a5c-91c5-53ea0aa1869f.gif" width="250">

Link to the issue: "n/a"

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/asoul-sig/asouldocs/blob/main/.github/contributing.md).
- [ ] I have added test cases to cover the new code.
