### PR TITLE
Update alpine, golang, gosu, gotask to latest versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:alpine3.15 AS binarybuilder
+FROM golang:1.21-alpine3.18 AS binarybuilder
 RUN apk --no-cache --no-progress add --virtual \
     build-deps \
     build-base \
     git
 
 # Install Task
-RUN wget --quiet https://github.com/go-task/task/releases/download/v3.12.0/task_linux_amd64.tar.gz -O task_linux_amd64.tar.gz \
-  && sh -c 'echo "803d3c1752da31486cbfb4ddf7d8ba5e0fa8c8ebba8acf227a9cd76ff9901343  task_linux_amd64.tar.gz" | sha256sum -c' \
+RUN wget --quiet https://github.com/go-task/task/releases/download/v3.31.0/task_linux_amd64.tar.gz -O task_linux_amd64.tar.gz \
+  && sh -c 'echo "fc707db87c08579066e312b6fd3de4301f7c1c3e48198a86368d063efce2bbab task_linux_amd64.tar.gz" | sha256sum -c' \
   && tar -xzf task_linux_amd64.tar.gz \
   && mv task /usr/local/bin/task
 
@@ -14,23 +14,23 @@ WORKDIR /dist
 COPY . .
 RUN task build
 
-FROM alpine:3.15
+FROM golang:1.21-alpine3.18
 RUN echo https://dl-cdn.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories \
   && apk --no-cache --no-progress add \
   ca-certificates \
   git
 
 # Install gosu
-RUN export url="https://github.com/tianon/gosu/releases/download/1.14/gosu-"; \
+RUN export url="https://github.com/tianon/gosu/releases/download/1.17/gosu-"; \
   if [ `uname -m` == "aarch64" ]; then \
        wget --quiet ${url}arm64 -O /usr/sbin/gosu \
-    && sh -c 'echo "73244a858f5514a927a0f2510d533b4b57169b64d2aa3f9d98d92a7a7df80cea  /usr/sbin/gosu" | sha256sum -c'; \
+    && sh -c 'echo "c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b /usr/sbin/gosu" | sha256sum -c'; \
   elif [ `uname -m` == "armv7l" ]; then \
        wget --quiet ${url}armhf -O /usr/sbin/gosu \
-    && sh -c 'echo "abb1489357358b443789571d52b5410258ddaca525ee7ac3ba0dd91d34484589  /usr/sbin/gosu" | sha256sum -c'; \
+    && sh -c 'echo "e5866286277ff2a2159fb9196fea13e0a59d3f1091ea46ddb985160b94b6841b /usr/sbin/gosu" | sha256sum -c'; \
   else \
        wget --quiet ${url}amd64 -O /usr/sbin/gosu \
-    && sh -c 'echo "bd8be776e97ec2b911190a82d9ab3fa6c013ae6d3121eea3d0bfd5c82a0eaf8c  /usr/sbin/gosu" | sha256sum -c'; \
+    && sh -c 'echo "bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3 /usr/sbin/gosu" | sha256sum -c'; \
   fi \
   && chmod +x /usr/sbin/gosu
 


### PR DESCRIPTION
### Describe the pull request

Updating alpine, golang, gosu and gotask.

My initial problem is ca-certficates not being up to date so a checkout from a git repository using letsencrypt is failing:

```
2023/11/11 23:37:59 [ INFO] ASoulDocs 1.0.0+dev
2023/11/11 23:37:59 [TRACE] Reloading https://repos.fbpx.io/chix/docs.git...
2023/11/11 23:37:59 [TRACE] Cloning https://repos.fbpx.io/chix/docs.git...
2023/11/11 23:37:59 [FATAL] [...ig/asouldocs/internal/cmd/web.go:47 runWeb()] Failed to init store: reload: clone "https://repos.fbpx.io/chix/docs.git": exit status 128 - Cloning into 'data/docs'...
fatal: unable to access 'https://repos.fbpx.io/chix/docs.git/': SSL certificate problem: self signed certificate
``` 

For reference:

Docker Golang Alpine Image:
https://hub.docker.com/_/golang/tags?page=1&name=alpine

Gotask releases:
https://github.com/go-task/task/releases

Gosu releases:
https://github.com/tianon/gosu/releases


Link to the issue: <!-- paste the issue link here, or put "n/a" if not applicable -->

### Checklist

- [ x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [ x] I have read and acknowledge the [Contributing guide](https://github.com/asoul-sig/asouldocs/blob/main/.github/contributing.md).
- [ x] I have added test cases to cover the new code.
