### PR TITLE
Dependabot: Enable version updates for GitHub action workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
       - "asoul-sig/core"
     commit-message:
       prefix: "mod:"
+  # Enable version updates for GitHub action workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates to GitHub Actions every weekday
+    schedule:
+      interval: "daily"
+      time: "19:00"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,9 @@ updates:
       - "asoul-sig/core"
     commit-message:
       prefix: "mod:"
-  # Enable version updates for GitHub action workflows
   - package-ecosystem: "github-actions"
     directory: "/"
-    # Check for updates to GitHub Actions every weekday
     schedule:
-      interval: "daily"
-      time: "19:00"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    reviewers:
+      - "asoul-sig/core"


### PR DESCRIPTION
This PR enable version updates checking for GitHub action workflows via dependabot.

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/asoul-sig/asouldocs/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
