### PR TITLE
ci: fix warning in GitHub test action workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,11 +46,11 @@ jobs:
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Run tests
         run: go test -v -race ./...


### PR DESCRIPTION
When running GitHub action workflow test, mutliple [warnings](https://github.com/asoul-sig/asouldocs/actions/runs/12573860689) are emitted:

```
Restore cache failed: Dependencies file is not found in /Users/runner/work/asouldocs/asouldocs.
Supported file pattern: go.sum
```

This PR fixes that issue.

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/asoul-sig/asouldocs/blob/main/.github/contributing.md).

